### PR TITLE
HVSBS-87: Add user suspend/reactivate/delete logic

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,13 +1,13 @@
 package main
 
-// "github.com/ajonesb/user-management/backend/internal/controllers"
-// "github.com/ajonesb/user-management/backend/internal/middleware"
-// "github.com/ajonesb/user-management/backend/internal/repositories"
-// "github.com/ajonesb/user-management/backend/internal/services"
-// "github.com/ajonesb/user-management/backend/pkg/config"
-// "github.com/ajonesb/user-management/backend/pkg/database"
-// "github.com/gin-contrib/cors"
-// "github.com/gin-gonic/gin"
+"github.com/dimitar728/virtual-showroom/backend/internal/controllers"
+"github.com/dimitar728/virtual-showroom/backend/internal/middleware"
+"github.com/dimitar728/virtual-showroom/backend/internal/repositories"
+"github.com/dimitar728/virtual-showroom/backend/internal/services"
+"github.com/dimitar728/virtual-showroom/backend/pkg/config"
+"github.com/dimitar728/virtual-showroom/backend/pkg/database"
+"github.com/gin-contrib/cors"
+"github.com/gin-gonic/gin"
 
 func main() {
 

--- a/backend/internal/handlers/admin.go
+++ b/backend/internal/handlers/admin.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"github.com/dimitar728/virtual-showroom/backend/internal/database"
+	"github.com/dimitar728/virtual-showroom/backend/internal/models"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// Suspend a user
+func SuspendUser(c *fiber.Ctx) error {
+	id := c.Params("id")
+	if err := database.DB.Model(&models.User{}).
+		Where("id = ?", id).
+		Update("status", models.StatusSuspended).Error; err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "Failed to suspend user"})
+	}
+	return c.JSON(fiber.Map{"message": "User suspended"})
+}
+
+// Reactivate a user
+func ReactivateUser(c *fiber.Ctx) error {
+	id := c.Params("id")
+	if err := database.DB.Model(&models.User{}).
+		Where("id = ?", id).
+		Update("status", models.StatusActive).Error; err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "Failed to reactivate user"})
+	}
+	return c.JSON(fiber.Map{"message": "User reactivated"})
+}
+
+// Delete a user
+func DeleteUser(c *fiber.Ctx) error {
+	id := c.Params("id")
+	if err := database.DB.Delete(&models.User{}, "id = ?", id).Error; err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "Failed to delete user"})
+	}
+	return c.JSON(fiber.Map{"message": "User deleted"})
+}

--- a/backend/internal/handlers/auth.go
+++ b/backend/internal/handlers/auth.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"github.com/dimitar728/virtual-showroom/backend/internal/database"
+	"github.com/dimitar728/virtual-showroom/backend/internal/models"
+
+	"github.com/gofiber/fiber/v2"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func Login(c *fiber.Ctx) error {
+	var body struct {
+		Email    string `json:"email"`
+		Password string `json:"password"`
+	}
+	if err := c.BodyParser(&body); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request"})
+	}
+
+	var user models.User
+	if err := database.DB.Where("email = ?", body.Email).First(&user).Error; err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid email or password"})
+	}
+
+	if err := c.BodyParser(&body); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid request"})
+	}
+
+	var user models.User
+	if err := database.DB.Where("email = ?", body.Email).First(&user).Error; err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid email or password"})
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(body.Password)); err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Invalid email or password"})
+	}
+
+	// Generate JWT token
+	token, err := middleware.GenerateJWT(user.ID, user.Role)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "Failed to generate token"})
+	}
+
+	if user.Status == models.StatusSuspended {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "Account suspended"})
+	}
+
+	return c.JSON(fiber.Map{"token": token})
+}

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -1,0 +1,11 @@
+package models
+
+type UserRole string
+
+const (
+	RoleUser  UserRole = "user"
+	RoleAdmin UserRole = "admin"
+
+	StatusActive    UserStatus = "active"
+	StatusSuspended UserStatus = "suspended"
+)

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -1,0 +1,15 @@
+package routes
+
+import (
+	"github.com/dimitar728/virtual-showroom/backend/internal/handlers"
+	"github.com/dimitar728/virtual-showroom/backend/internal/middleware"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func SetupRoutes(app *fiber.App) {
+
+	admin.Patch("/users/:id/suspend", handlers.SuspendUser)
+	admin.Patch("/users/:id/reactivate", handlers.ReactivateUser)
+	admin.Delete("/users/:id", handlers.DeleteUser)
+}


### PR DESCRIPTION
**Overview**

This PR introduces user account management controls for administrators. Admins can now suspend, reactivate, or delete users. Suspended users are prevented from logging in and accessing protected features.

**Jira**
https://albertjs3232.atlassian.net/jira/core/projects/HVSBS/board?groupBy=status&selectedIssue=HVSBS-87

**Changes**

- Model Updates

Added status field (active / suspended) to User model.

- Auth Updates

Block login for suspended users.

- Admin Endpoints

PATCH /api/admin/users/:id/suspend → Suspend a user.

PATCH /api/admin/users/:id/reactivate → Reactivate a user.

DELETE /api/admin/users/:id → Delete a user.

- Access Control

All new endpoints are restricted to admin role.

Close HVSBS-87