### PR TITLE
HVSBS-89 feat: implement showrooms table and CRUD routes

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,13 +1,13 @@
 package main
 
-// "github.com/ajonesb/user-management/backend/internal/controllers"
-// "github.com/ajonesb/user-management/backend/internal/middleware"
-// "github.com/ajonesb/user-management/backend/internal/repositories"
-// "github.com/ajonesb/user-management/backend/internal/services"
-// "github.com/ajonesb/user-management/backend/pkg/config"
-// "github.com/ajonesb/user-management/backend/pkg/database"
-// "github.com/gin-contrib/cors"
-// "github.com/gin-gonic/gin"
+"github.com/dimitar728/virtual-showroom/backend/internal/controllers"
+"github.com/dimitar728/virtual-showroom/backend/internal/middleware"
+"github.com/dimitar728/virtual-showroom/backend/internal/repositories"
+"github.com/dimitar728/virtual-showroom/backend/internal/services"
+"github.com/dimitar728/virtual-showroom/backend/pkg/config"
+"github.com/dimitar728/virtual-showroom/backend/pkg/database"
+"github.com/gin-contrib/cors"
+"github.com/gin-gonic/gin"
 
 func main() {
 

--- a/backend/internal/controllers/showroom_controller.go
+++ b/backend/internal/controllers/showroom_controller.go
@@ -1,0 +1,82 @@
+package controllers
+
+import (
+	"github.com/dimitar728/virtual-showroom/backend/internal/database"
+	"github.com/dimitar728/virtual-showroom/backend/internal/models"
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// GET /api/showrooms
+func GetShowrooms(c *fiber.Ctx) error {
+	var showrooms []models.Showroom
+	if err := database.DB.Find(&showrooms).Error; err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to fetch showrooms"})
+	}
+	return c.JSON(showrooms)
+}
+
+// GET /api/showrooms/:id
+func GetShowroomByID(c *fiber.Ctx) error {
+	id := c.Params("id")
+	var showroom models.Showroom
+
+	if err := database.DB.First(&showroom, "id = ?", id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return c.Status(404).JSON(fiber.Map{"error": "showroom not found"})
+		}
+		return c.Status(500).JSON(fiber.Map{"error": "failed to fetch showroom"})
+	}
+	return c.JSON(showroom)
+}
+
+// POST /api/showrooms (admin only)
+func CreateShowroom(c *fiber.Ctx) error {
+	var body models.Showroom
+	if err := c.BodyParser(&body); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
+	}
+
+	if body.Name == "" || body.ModelPath == "" {
+		return c.Status(400).JSON(fiber.Map{"error": "name and model_path required"})
+	}
+
+	// Extract admin ID from context (set by middleware)
+	adminID := c.Locals("userID").(uuid.UUID)
+	body.CreatedBy = adminID
+
+	if err := database.DB.Create(&body).Error; err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to create showroom"})
+	}
+	return c.Status(201).JSON(body)
+}
+
+// PATCH /api/showrooms/:id (admin only)
+func UpdateShowroom(c *fiber.Ctx) error {
+	id := c.Params("id")
+	var showroom models.Showroom
+
+	if err := database.DB.First(&showroom, "id = ?", id).Error; err != nil {
+		return c.Status(404).JSON(fiber.Map{"error": "showroom not found"})
+	}
+
+	var body map[string]interface{}
+	if err := c.BodyParser(&body); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
+	}
+
+	if err := database.DB.Model(&showroom).Updates(body).Error; err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to update showroom"})
+	}
+	return c.JSON(showroom)
+}
+
+// DELETE /api/showrooms/:id (admin only)
+func DeleteShowroom(c *fiber.Ctx) error {
+	id := c.Params("id")
+	if err := database.DB.Delete(&models.Showroom{}, "id = ?", id).Error; err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to delete showroom"})
+	}
+	return c.SendStatus(204)
+}

--- a/backend/internal/models/showroom.go
+++ b/backend/internal/models/showroom.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type Showroom struct {
+	ID          uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	Name        string    `gorm:"not null" json:"name"`
+	Description string    `json:"description"`
+	ModelPath   string    `gorm:"not null" json:"model_path"`
+	Capacity    int       `json:"capacity"`
+	CreatedBy   uuid.UUID `gorm:"type:uuid;not null" json:"created_by"`
+	CreatedAt   time.Time `gorm:"autoCreateTime" json:"created_at"`
+}
+
+// Auto-generate UUID before insert
+func (s *Showroom) BeforeCreate(tx *gorm.DB) (err error) {
+	s.ID = uuid.New()
+	return
+}

--- a/backend/internal/routes/showroom_routes.go
+++ b/backend/internal/routes/showroom_routes.go
@@ -1,0 +1,20 @@
+package routes
+
+import (
+	"github.com/dimitar728/virtual-showroom/backend/internal/controllers"
+	"github.com/dimitar728/virtual-showroom/backend/internal/middleware"
+	"github.com/gofiber/fiber/v2"
+)
+
+func ShowroomRoutes(app *fiber.App) {
+	route := app.Group("/api/showrooms")
+
+	// Public
+	route.Get("/", controllers.GetShowrooms)
+	route.Get("/:id", controllers.GetShowroomByID)
+
+	// Admin only
+	route.Post("/", middleware.RequireAuth, middleware.RequireAdmin, controllers.CreateShowroom)
+	route.Patch("/:id", middleware.RequireAuth, middleware.RequireAdmin, controllers.UpdateShowroom)
+	route.Delete("/:id", middleware.RequireAuth, middleware.RequireAdmin, controllers.DeleteShowroom)
+}


### PR DESCRIPTION
**Summary**

Implements the Showroom management feature, enabling admins to create, update, and delete showroom spaces, and allowing all users to view available showrooms.

**Jira**

https://albertjs3232.atlassian.net/jira/core/projects/HVSBS/board?groupBy=status&selectedIssue=HVSBS-89

**Changes** Made

Added Showroom model with fields: id, name, description, model_path, capacity, created_by, created_at.

Implemented database migration for showrooms table.

Added /api/showrooms routes:

GET /api/showrooms — list all showrooms

GET /api/showrooms/:id — fetch showroom details

POST /api/showrooms — create showroom (admin only)

PATCH /api/showrooms/:id — update showroom (admin only)

DELETE /api/showrooms/:id — delete showroom (admin only)

Integrated role-based middleware for admin-only routes.

Added error handling for invalid IDs and missing fields.

**Technical Notes**

Uses UUID as primary key for consistency across tables.

Auto-generates IDs via GORM BeforeCreate hook.

model_path is stored as a string for now (to be extended with file upload validation in a later ticket).

Admin ID is attached from JWT context to created_by field.

**Testing Steps**

Log in as an admin user with a valid JWT.

Send POST /api/showrooms with name and model_path to create a showroom.

Verify new entry is saved in DB and returned in response.

Call GET /api/showrooms to confirm it lists all showrooms.

Call PATCH /api/showrooms/:id to update fields.

Call DELETE /api/showrooms/:id to remove a showroom.

Log in as a regular user and confirm only GET endpoints are accessible.

**Checklist**

 Code follows style guidelines

 All tests pass locally

 API documentation updated

 Role-based access confirmed

 No secrets committed

Closes HVSBS-89