### PR TITLE
HVSBS-90 feat: add admin upload/update/delete showroom

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,13 +1,13 @@
 package main
 
-// "github.com/ajonesb/user-management/backend/internal/controllers"
-// "github.com/ajonesb/user-management/backend/internal/middleware"
-// "github.com/ajonesb/user-management/backend/internal/repositories"
-// "github.com/ajonesb/user-management/backend/internal/services"
-// "github.com/ajonesb/user-management/backend/pkg/config"
-// "github.com/ajonesb/user-management/backend/pkg/database"
-// "github.com/gin-contrib/cors"
-// "github.com/gin-gonic/gin"
+"github.com/dimitar728/virtual-showroom/backend/internal/controllers"
+"github.com/dimitar728/virtual-showroom/backend/internal/middleware"
+"github.com/dimitar728/virtual-showroom/backend/internal/repositories"
+"github.com/dimitar728/virtual-showroom/backend/internal/services"
+"github.com/dimitar728/virtual-showroom/backend/pkg/config"
+"github.com/dimitar728/virtual-showroom/backend/pkg/database"
+"github.com/gin-contrib/cors"
+"github.com/gin-gonic/gin"
 
 func main() {
 

--- a/backend/internal/controllers/showroom_controller.go
+++ b/backend/internal/controllers/showroom_controller.go
@@ -1,0 +1,104 @@
+package controllers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dimitar728/virtual-showroom/backend/internal/database"
+	"github.com/dimitar728/virtual-showroom/backend/internal/models"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// GET /api/showrooms
+func CreateShowroom(c *fiber.Ctx) error {
+	// Parse text fields
+	name := c.FormValue("name")
+	description := c.FormValue("description")
+	capacity := c.FormValue("capacity")
+
+	if name == "" {
+		return c.Status(400).JSON(fiber.Map{"error": "name is required"})
+	}
+
+	// Handle file upload
+	file, err := c.FormFile("model")
+	if err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "model file required"})
+	}
+	if err := validateModelFile(file); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	// Save file locally (later → S3 or Cloudinary)
+	filename := fmt.Sprintf("uploads/models/%d_%s", time.Now().Unix(), file.Filename)
+	if err := c.SaveFile(file, filename); err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to save model"})
+	}
+
+	// Build showroom record
+	adminID := c.Locals("userID").(uuid.UUID)
+	showroom := models.Showroom{
+		Name:        name,
+		Description: description,
+		ModelPath:   filename,
+		CreatedBy:   adminID,
+		CreatedAt:   time.Now(),
+	}
+
+	if capacity != "" {
+		fmt.Sscan(capacity, &showroom.Capacity)
+	}
+
+	if err := database.DB.Create(&showroom).Error; err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to create showroom"})
+	}
+	return c.Status(201).JSON(showroom)
+}
+
+func UpdateShowroom(c *fiber.Ctx) error {
+	id := c.Params("id")
+	var showroom models.Showroom
+
+	if err := database.DB.First(&showroom, "id = ?", id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return c.Status(404).JSON(fiber.Map{"error": "showroom not found"})
+		}
+		return c.Status(500).JSON(fiber.Map{"error": "db error"})
+	}
+
+	// Parse updates
+	name := c.FormValue("name")
+	description := c.FormValue("description")
+	capacity := c.FormValue("capacity")
+
+	if name != "" {
+		showroom.Name = name
+	}
+	if description != "" {
+		showroom.Description = description
+	}
+	if capacity != "" {
+		fmt.Sscan(capacity, &showroom.Capacity)
+	}
+
+	// Optional file update
+	file, _ := c.FormFile("model")
+	if file != nil {
+		if err := validateModelFile(file); err != nil {
+			return c.Status(400).JSON(fiber.Map{"error": err.Error()})
+		}
+		filename := fmt.Sprintf("uploads/models/%d_%s", time.Now().Unix(), file.Filename)
+		if err := c.SaveFile(file, filename); err != nil {
+			return c.Status(500).JSON(fiber.Map{"error": "failed to save model"})
+		}
+		showroom.ModelPath = filename
+	}
+
+	if err := database.DB.Save(&showroom).Error; err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to update showroom"})
+	}
+	return c.JSON(showroom)
+}


### PR DESCRIPTION
**Summary**

Adds full admin functionality for managing showrooms, including the ability to upload new 3D models, update existing showroom metadata or model files, and delete showroom entries.

**Jira**

https://albertjs3232.atlassian.net/jira/core/projects/HVSBS/board?groupBy=status&selectedIssue=HVSBS-90

**Changes Made**

Extended Showroom controller with file upload support.

Implemented validation for .glb and .gltf files (max size: 50MB).

Configured storage of uploaded models in /uploads/models.

Added logic in PATCH /api/showrooms/:id to optionally update metadata (name, description, capacity) and replace model files.

Finalized DELETE /api/showrooms/:id for admin-only removal of showroom entries.

Enforced role-based middleware to restrict upload/update/delete to admins only.

**Technical Notes**

Uses multipart/form-data for handling model uploads.

File paths are stored in model_path column in DB.

Future enhancement: move file storage from local filesystem to S3/Cloudinary.

Maintains UUIDs for consistency across tables.

**Testing Steps**

Log in as an admin user with valid JWT.

Send POST /api/showrooms with name, description, capacity, and a .glb file under model.

Verify showroom is created and file is saved in /uploads/models.

Send PATCH /api/showrooms/:id with updated metadata and/or new .glb file.

Confirm changes persist in DB and file path updates.

Send DELETE /api/showrooms/:id.

Verify record is removed from DB.

Attempt same operations as a normal user.

Confirm 403 Forbidden is returned.

**Checklist**

 Code follows style guidelines

 All tests pass locally

 Role-based access confirmed

 API documentation updated

 No secrets in code

Closes HVSBS-90