### PR TITLE
HVSBS-94 feat: add booking create/cancel/view endpoints

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,13 +1,13 @@
 package main
 
-// "github.com/ajonesb/user-management/backend/internal/controllers"
-// "github.com/ajonesb/user-management/backend/internal/middleware"
-// "github.com/ajonesb/user-management/backend/internal/repositories"
-// "github.com/ajonesb/user-management/backend/internal/services"
-// "github.com/ajonesb/user-management/backend/pkg/config"
-// "github.com/ajonesb/user-management/backend/pkg/database"
-// "github.com/gin-contrib/cors"
-// "github.com/gin-gonic/gin"
+"github.com/dimitar728/virtual-showroom/backend/internal/controllers"
+"github.com/dimitar728/virtual-showroom/backend/internal/middleware"
+"github.com/dimitar728/virtual-showroom/backend/internal/repositories"
+"github.com/dimitar728/virtual-showroom/backend/internal/services"
+"github.com/dimitar728/virtual-showroom/backend/pkg/config"
+"github.com/dimitar728/virtual-showroom/backend/pkg/database"
+"github.com/gin-contrib/cors"
+"github.com/gin-gonic/gin"
 
 func main() {
 

--- a/backend/internal/handlers/booking.go
+++ b/backend/internal/handlers/booking.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/dimitar728/virtual-showroom/backend/internal/models"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type BookingRequest struct {
+	ShowroomID string    `json:"showroom_id" binding:"required,uuid"`
+	SlotTime   time.Time `json:"slot_time" binding:"required"`
+}
+
+// POST /api/bookings
+func CreateBooking(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID := c.GetString("userID") // extracted from JWT middleware
+
+		var req BookingRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		// Prevent double booking
+		var count int64
+		db.Model(&models.Booking{}).
+			Where("showroom_id = ? AND slot_time = ? AND status != ?", req.ShowroomID, req.SlotTime, models.StatusCancelled).
+			Count(&count)
+
+		if count > 0 {
+			c.JSON(http.StatusConflict, gin.H{"error": "Slot already booked"})
+			return
+		}
+
+		booking := models.Booking{
+			UserID:     uuid.MustParse(userID),
+			ShowroomID: uuid.MustParse(req.ShowroomID),
+			SlotTime:   req.SlotTime,
+			Status:     models.StatusConfirmed,
+		}
+
+		if err := db.Create(&booking).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create booking"})
+			return
+		}
+
+		c.JSON(http.StatusCreated, booking)
+	}
+}
+
+// GET /api/bookings/me
+func GetMyBookings(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID := c.GetString("userID")
+
+		var bookings []models.Booking
+		if err := db.Where("user_id = ?", userID).Find(&bookings).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch bookings"})
+			return
+		}
+
+		c.JSON(http.StatusOK, bookings)
+	}
+}
+
+// PATCH /api/bookings/:id/cancel
+func CancelBooking(db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userID := c.GetString("userID")
+		bookingID := c.Param("id")
+
+		var booking models.Booking
+		if err := db.First(&booking, "id = ?", bookingID).Error; err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Booking not found"})
+			return
+		}
+
+		// Only owner or admin can cancel
+		role := c.GetString("role")
+		if booking.UserID.String() != userID && role != "admin" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized"})
+			return
+		}
+
+		booking.Status = models.StatusCancelled
+		if err := db.Save(&booking).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to cancel booking"})
+			return
+		}
+
+		c.JSON(http.StatusOK, booking)
+	}
+}

--- a/backend/internal/models/booking.go
+++ b/backend/internal/models/booking.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type BookingStatus string
+
+const (
+	StatusPending   BookingStatus = "pending"
+	StatusConfirmed BookingStatus = "confirmed"
+	StatusCancelled BookingStatus = "cancelled"
+)
+
+func (b *Booking) BeforeCreate(tx *gorm.DB) (err error) {
+	b.ID = uuid.New()
+	b.CreatedAt = time.Now()
+	return
+}


### PR DESCRIPTION
**Summary**

Implements booking functionality in the backend, allowing authenticated users to create, view, and cancel bookings for showrooms. Includes double-booking prevention and role-based cancellation logic.

**Jira**

https://albertjs3232.atlassian.net/jira/core/projects/HVSBS/board?groupBy=status&selectedIssue=HVSBS-94

**Changes Made**

Added Booking model with status enum (pending, confirmed, cancelled).

Implemented POST /api/bookings for creating new bookings with slot availability check.

Implemented GET /api/bookings/me for users to view their own bookings.

Implemented PATCH /api/bookings/:id/cancel for users or admins to cancel bookings.

Integrated endpoints with JWT auth middleware and role-based access control.

Registered booking routes under /api/bookings.

**Technical Notes**

Prevents double-booking by checking existing records before insert.

Uses GORM hooks to auto-generate UUIDs and timestamps.

Status updates are persisted instead of hard-deleting bookings.

Designed to be compatible with future admin routes (/api/admin/bookings).

**Testing Steps**

Log in as a user and obtain JWT.

Send POST /api/bookings with a valid showroom ID and time slot → booking created.

Send GET /api/bookings/me → returns user’s bookings.

Send PATCH /api/bookings/:id/cancel → updates booking status to cancelled.

Attempt double-booking same slot → request should fail with 409 Conflict.

Attempt to cancel another user’s booking as non-admin → request should fail with 403 Forbidden.

**Checklist**

 Code follows style guidelines

 All endpoints tested in Postman

 Documentation updated with new routes

 JWT and role middleware applied correctly

**Closes HVSBS-94**