### PR TITLE
Feature/hvsbs 95/link bookings to authenticated users

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,13 +1,13 @@
 package main
 
-// "github.com/ajonesb/user-management/backend/internal/controllers"
-// "github.com/ajonesb/user-management/backend/internal/middleware"
-// "github.com/ajonesb/user-management/backend/internal/repositories"
-// "github.com/ajonesb/user-management/backend/internal/services"
-// "github.com/ajonesb/user-management/backend/pkg/config"
-// "github.com/ajonesb/user-management/backend/pkg/database"
-// "github.com/gin-contrib/cors"
-// "github.com/gin-gonic/gin"
+"github.com/dimitar728/virtual-showroom/backend/internal/controllers"
+"github.com/dimitar728/virtual-showroom/backend/internal/middleware"
+"github.com/dimitar728/virtual-showroom/backend/internal/repositories"
+"github.com/dimitar728/virtual-showroom/backend/internal/services"
+"github.com/dimitar728/virtual-showroom/backend/pkg/config"
+"github.com/dimitar728/virtual-showroom/backend/pkg/database"
+"github.com/gin-contrib/cors"
+"github.com/gin-gonic/gin"
 
 func main() {
 

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func AuthMiddleware(secret string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tokenStr := c.GetHeader("Authorization")
+		if tokenStr == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Missing token"})
+			return
+		}
+
+		token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+			return []byte(secret), nil
+		})
+		if err != nil || !token.Valid {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+			return
+		}
+
+		claims := token.Claims.(jwt.MapClaims)
+		c.Set("userID", claims["id"].(string))
+		c.Set("role", claims["role"].(string))
+		c.Next()
+	}
+}


### PR DESCRIPTION
**Summary**

Ensures all bookings are securely tied to the authenticated user making the request. The backend now derives user_id from JWT claims rather than relying on client-provided input, preventing impersonation or spoofing of other users.

**Jira**

https://albertjs3232.atlassian.net/jira/core/projects/HVSBS/board?groupBy=status&selectedIssue=HVSBS-95

**Changes Made**

Extended AuthMiddleware to set userID and role from JWT claims into the Gin context.

Updated POST /api/bookings to use userID from context instead of request body.

Confirmed GET /api/bookings/me correctly filters by the authenticated user.

Preserved role-based logic in PATCH /api/bookings/:id/cancel (user can cancel own booking, admin can cancel any).

**Technical Notes**

Eliminates the need for user_id in the booking request payload.

Prevents malicious clients from booking on behalf of other users.

Aligns booking flow with secure JWT authentication and RBAC model.

**Testing Steps**

Log in as a user and obtain JWT.

Send POST /api/bookings with showroom ID + slot time (no user_id in payload).

Verify booking is linked to the logged-in user.

Call GET /api/bookings/me → returns only that user’s bookings.

Log in as a different user → their /bookings/me list is separate.

Attempt to manually include a fake user_id in booking request → ignored, booking still links to authenticated user.

**Checklist**

 Code follows style guidelines

 Verified bookings always tied to JWT user

 Manual tests confirm security fix

 Documentation updated with request/response examples

**Closes HVSBS-95**